### PR TITLE
[Fix] Transaction, Timestamp, and Announcement Modal

### DIFF
--- a/frontend/src/assets/css/components/TextField.css
+++ b/frontend/src/assets/css/components/TextField.css
@@ -46,6 +46,7 @@
     border-radius: 5px;
     font-weight: 500;
     outline: none; 
+    white-space: pre-wrap;
 }
 .TextField__textarea::placeholder {
     font-style: italic; 

--- a/frontend/src/assets/css/customer/Transaction.css
+++ b/frontend/src/assets/css/customer/Transaction.css
@@ -108,6 +108,11 @@
     max-width: 90px;
 }
   
+.Transaction__no-message{
+    color: #cecece;
+    margin-left: 15px;
+    font-size: 16px;
+}
   
 /* not found */
 .Transaction__not-found{
@@ -255,7 +260,13 @@
         font-size: 9px;
 
     }
+    
 
+    .Transaction__no-message{
+        color: #cecece;
+        margin-left: 10px;
+        font-size: 13px;
+    }
     
     /* pagination */
     .Transaction__pagination {

--- a/frontend/src/components/ConcernSpecific.js
+++ b/frontend/src/components/ConcernSpecific.js
@@ -135,7 +135,8 @@ export const ConcernSpecific = ({ selectedConcern, handleBackClick, isAdmin, mar
                 </div>
 
                 <div className="ConcernAdmin__specific-content">
-                    {selectedConcern.content}
+                    <span style={{ whiteSpace: 'pre-wrap' }}>{selectedConcern.content}</span>
+                    
                     {selectedConcern.images && selectedConcern.images.length > 0 && (
                     <div className="ConcernAdmin__attachments">
                         <h4>Attachments:</h4>
@@ -226,7 +227,9 @@ export const ConcernSpecific = ({ selectedConcern, handleBackClick, isAdmin, mar
                                 </div>
                                 <span className="ConcernAdmin__reply-time">{formatTimeDisplay(reply.created_at)}</span>
                             </div>      
-                            <div className="ConcernAdmin__reply-message">{reply.content}</div>
+                            <div className="ConcernAdmin__reply-message">
+                                <span style={{ whiteSpace: 'pre-wrap' }}> {reply.content}</span>
+                            </div>
                         </div>
                     </div>
                 ))}

--- a/frontend/src/layouts/main_layouts/AdminLayout.js
+++ b/frontend/src/layouts/main_layouts/AdminLayout.js
@@ -46,6 +46,7 @@ export const AdminLayout = () => {
 
   const toggleNotifications = () => {
     setNotificationsVisible(!notificationsVisible);
+    fetchNotifications();
   };
 
   const handleSeeAllClick = () => {
@@ -179,7 +180,7 @@ export const AdminLayout = () => {
             }
         });
         const sortedNotifications = response.data.data.sort((a, b) => {
-            return new Date(b.updated_at) - new Date(a.updated_at);
+            return new Date(b.created_at) - new Date(a.created_at);
         });
 
         setAuthUserObj(prevState => ({

--- a/frontend/src/layouts/main_layouts/CustomerLayout.js
+++ b/frontend/src/layouts/main_layouts/CustomerLayout.js
@@ -202,7 +202,7 @@ export const CustomerLayout = () =>{
             }
         });
         const sortedNotifications = response.data.data.sort((a, b) => {
-            return new Date(b.updated_at) - new Date(a.updated_at);
+            return new Date(b.created_at) - new Date(a.created_at);
         });
 
 
@@ -292,7 +292,7 @@ export const CustomerLayout = () =>{
                           <div className={`CustomerLayout__notification-details-header ${notification.is_read ? '' : 'CustomerLayout__new-notification'}`} onClick={() => handleNotificationClick(notification)}>
                             <p className="CustomerLayout__notification-subject-header">{notification.subject}</p>
                             <p className="CustomerLayout__notification-description-header">{notification.description}</p>
-                            <p className="CustomerLayout__notification-time-header">{formatTimeAgo(notification.updated_at)}</p>
+                            <p className="CustomerLayout__notification-time-header">{formatTimeAgo(notification.created_at)}</p>
                             {notification.is_read ? '' : <div className="CustomerLayout__blue-circle"></div>}
                           </div>
                         </div>

--- a/frontend/src/pages/admin/concern/ConcernsAdmin.js
+++ b/frontend/src/pages/admin/concern/ConcernsAdmin.js
@@ -177,7 +177,7 @@ const handleFilterChange = (name, value) => {
   return (
     <>
       <div className="ConcernAdmin__header">
-        <h2 className="ConcernAdmin__header-text">Customer Concerns</h2>
+        <h2 className="ConcernAdmin__header-text" onClick={()=>fetchConcern()}>Customer Concerns</h2>
       </div>
       {!selectedConcern ? (
         <>

--- a/frontend/src/pages/customer/concern/Concern.js
+++ b/frontend/src/pages/customer/concern/Concern.js
@@ -100,7 +100,7 @@ export const Concern = () =>{
     return(
         <>
             <div className="Concern__header">
-                <h2 className="Concern__header-text">Customer Concerns</h2>
+                <h2 className="Concern__header-text" onClick={()=>fetchConcern()}>Customer Concerns</h2>
                 <p className="Concern__description">
                     If you have any comments, concerns, or if you need help with your requests, let us know.
                     We're committed to assisting you and delivering quality service!

--- a/frontend/src/pages/customer/dashboard/modals/AnnouncementViewModal.js
+++ b/frontend/src/pages/customer/dashboard/modals/AnnouncementViewModal.js
@@ -24,7 +24,7 @@ export const AnnouncementViewModal = ({isOpen, onClose, announcement}) =>{
                     </div>
                     
                     <p className="AnnouncementViewModal__summary">
-                        {announcement.content}
+                        <span style={{ whiteSpace: 'pre-wrap' }}>{announcement.content}</span>
                     </p>
 
                     <div className="AnnouncementViewModal__footer">

--- a/frontend/src/pages/customer/notification/Notification.js
+++ b/frontend/src/pages/customer/notification/Notification.js
@@ -53,7 +53,7 @@ export const Notification = () =>{
                 }
             });
             const sortedNotifications = response.data.data.sort((a, b) => {
-                return new Date(b.updated_at) - new Date(a.updated_at);
+                return new Date(b.created_at) - new Date(a.created_at);
             });
 
             setNotifications(sortedNotifications);
@@ -114,7 +114,7 @@ export const Notification = () =>{
                             <div className={`Notification__details ${notification.is_read ? '' : 'Notification__new-notification'}`} onClick={() => handleNotificationClick(notification)} >
                                 <p className="Notification__subject">{notification.subject}</p>
                                 <p className="Notification__description">{notification.description}</p>
-                                <p className="Notification__time">{formatTimeAgo(notification.updated_at)}</p>
+                                <p className="Notification__time">{formatTimeAgo(notification.created_at)}</p>
                                 {notification.is_read ? '' : <div className="Notification__blue-circle"/>}
                             </div>
                         </div>

--- a/frontend/src/pages/customer/transaction/Transaction.js
+++ b/frontend/src/pages/customer/transaction/Transaction.js
@@ -273,7 +273,7 @@ export const Transaction = () =>{
                                         </span>
                                     )} 
                                 </td>
-                                <td>₱{transaction.totalPrice.toFixed(2)}</td>
+                                <td>{transaction.request_type === 'return' ? <span className="Transaction__no-message">-</span> : `₱${transaction.totalPrice.toFixed(2)}`}</td>
                                 <td style={{color: getStatusColor(capitalize(transaction.status))}}>{capitalize(transaction.status)}</td>
                             </tr>
                         )))}

--- a/frontend/src/pages/customer/transaction/modals/TransactionDetailsModal.js
+++ b/frontend/src/pages/customer/transaction/modals/TransactionDetailsModal.js
@@ -55,7 +55,7 @@ export const TransactionDetailsModal = ({isOpen, onClose, transaction}) =>{
                     </div>
                     <div className="TransactionDetailsModal__info-row">
                         <span className="TransactionDetailsModal__label">Total Amount:</span>
-                        <span className="TransactionDetailsModal__value">₱{transaction.totalPrice.toFixed(2)}</span>
+                        <span className="TransactionDetailsModal__value">{transaction.request_type === 'return' ? <span className="Transaction__no-message">-</span> : `₱${transaction.totalPrice.toFixed(2)}`}</span>
                     </div>
                     <div className="TransactionDetailsModal__info-row">
                         <span className="TransactionDetailsModal__label">Status:</span>


### PR DESCRIPTION
- Updated the **transaction table** to show a `dash` for **return gallon types** instead of the total amount.
- Changed notification's `updated_at` to `created_at` for accurate timestamp.
- Added `whitespace wrap` in the **announcement view modal** and **customer-specific content**.